### PR TITLE
fix test_set for MLP

### DIFF
--- a/scripts/census_income/MLPClassifier.ipynb
+++ b/scripts/census_income/MLPClassifier.ipynb
@@ -53,6 +53,9 @@
     "\n",
     "test_data_file = (\"../../input/census_income/adult.test\")\n",
     "test_data = pd.read_csv(test_data_file, header=None, names=CSV_HEADER)\n",
+    "test_data.income_bracket = test_data.income_bracket.apply(\n",
+    "    lambda value: value.replace(\".\", \"\")\n",
+    ")\n",
     "\n",
     "print(f\"Train dataset shape: {train_data.shape}\")\n",
     "print(f\"Test dataset shape: {test_data.shape}\")"
@@ -148,7 +151,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8494564215957251"
+       "0.814937657392052"
       ]
      },
      "execution_count": 5,
@@ -179,7 +182,7 @@
     {
      "data": {
       "text/plain": [
-       "0.853510226644555"
+       "0.8503777409250046"
       ]
      },
      "execution_count": 6,
@@ -219,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I think this line might have gotten misplaced in the notebook, it was giving an accuracy of 0 due to the `.` at the end of the labels in test.

What slightly worries me is that even with the seed set on the 2nd MLP I am getting a slightly different accuracy than you were getting, 0.8503777409250046 vs 0.853510226644555 that you got. Could it be due to different sklearn versions?!

Really cool to be able to follow along this work! 🙂 